### PR TITLE
Add 2021 Contributor Meeting Talk/Q&A Notes

### DIFF
--- a/Sources/WebKit/WebKit.docc/Other/ContributorMeetings/2021/2021.md
+++ b/Sources/WebKit/WebKit.docc/Other/ContributorMeetings/2021/2021.md
@@ -35,11 +35,11 @@ WebKit Contributors Meeting September 27-28, 2021
 
 ## Transcripts
 
-* WebKit 2021/2022 Igalia
-* Apple Plans for WebKit: 2022 Edition
-* Protected Collaboration Tree
-* GitHub and New Processes
-* OffscreenCanvas 2021 Update
+* <doc:2021IgaliaUpdate>
+* <doc:2021AppleWebKitPlans>
+* <doc:2021ProtectedCollaborationTree>
+* <doc:2021GitHub>
+* <doc:2021OffscreenCanvas>
 * WPT Update
 * Introduction to LFC
 * GPU Process

--- a/Sources/WebKit/WebKit.docc/Other/ContributorMeetings/2021/2021AppleWebKitPlans.md
+++ b/Sources/WebKit/WebKit.docc/Other/ContributorMeetings/2021/2021AppleWebKitPlans.md
@@ -1,0 +1,47 @@
+# Apple Plans for WebKit: 2022 Edition
+
+## Overview
+
+Speaker : Maciej Stachowiak
+
+## Q&A
+
+Chris Lord: Have you looked at/considered CSS Scroll-linked animations?
+
+maciej: we are interested, but don’t think it’s an immediate goal. I think we were among the earliest to propose - better than hand-rolled per-site.
+
+jen simmons: spec still under a lot of development
+
+Xan Lopez: Is xcbuild same file format, easier to add files manually?
+
+maciej: xcbuild replaced xcodebuild - I think the format is different, but not readily hand-editable. Considering systems where everything can be edited in human-readable plain-text files. I don’t think it solves this problem.
+
+Brian Kardell: No q, but this is an exciting list of things.
+
+alexg: Can you share how PLT5 works?
+
+maciej: At a high level, we have a system for capturing webpage content and then using a server that can handle serving, load the captured copy. Locally set up device with root cert to MITM the sites via a redirect to local server. Measures first meaningful paint, time to dom content loaded, subresources loaded. Considering better approach to what we consider a complete load of the page. Users don’t see subresources loading typically.
+
+Brian Kardell: Having a lot of conversations with Chrome re: :has() I wonder there is an opportunity to have someone involved more directly in those convos instead of a lot of go-between. (edited)
+
+maciej: I’m not the best to answer those questions, but it would be good to have one or more of our engineers in the area involved, yes.
+
+Jen: Open issues on the CSSWG repo for these conversations. Of course there are times where a deeper dive is needed, but for the need to have collaboration, the CSSWG is a great place to do that.
+
+maciej: Standards groups are the first choice for venue for these discussions.
+
+Brian Kardell: The WG is stuck on “how to solve all the problems” - end up in a circle not getting to the meat of the problem, come up with a proposal, etc. Trying to get proposals with enough critical thought around it.
+
+Myles: We are not interested in a WebGPU impl that isn’t in the GPU process.
+
+Saam: I don’t know if it would be helpful for folks to have a PLT capture tool, but maybe we can open source the tool itself. Reach out to me to continue the conversation.
+
+Brian Kardell: Can you explain more?
+
+Saam: It’s a proxy server to replay websites in a controlled environment.
+
+Brian Kardell: Has anyone considered the ability to report a bug from the dev tools for rendering/layout bugs?
+
+Carlos: I think PLT would be useful to us in open source - even without the content.
+
+Saam: I can look into that - When I first made it one of the ideas was to open source the tool - requires some amount of work for internal approval.

--- a/Sources/WebKit/WebKit.docc/Other/ContributorMeetings/2021/2021GitHub.md
+++ b/Sources/WebKit/WebKit.docc/Other/ContributorMeetings/2021/2021GitHub.md
@@ -1,0 +1,163 @@
+# GitHub and New Processes
+
+## Overview
+
+Speaker : Jonathan Bedard
+
+## Talk
+
+Jonathan: talking bout contribution workflows and what is planned and what is already implemented
+
+Jonathan: we've talked a lot about identifiers and many of our services have already started using them
+
+Jonathan: talking bout configuration settings for setting up access to the git repo
+
+Jonathan: command lines tools talk to GitHub with personal git access tokens
+
+the git-webkit setup scripts takes the token and saves it
+
+we also will be creating personal forks so that we don't pollute git webkit repo with personal development branches
+
+you will have multiple remotes: your origin, your fork, and other users forks if you are reviewing their code and want to download it
+
+we will be creating tooling to help with that
+
+when you get to making code change, like webkit patch, we will help automate
+
+git-webkit will take all your local changes, create a branch prefixed by eng/, open a git editor, populate the commit message
+
+we will be removing changelings when we move to git, they break merging workflows
+
+git-webkit will also do a set of pre commit checks, and display a final diff check, and then create pull request
+
+then slides were all pulled from a pull request last week and you can go check it out on our webkit repo on github
+
+ews is going to integrate with GitHub checks
+
+last thing to talk about is commit-queue
+
+our goals for cq are that we leverage GitHub ui, leverage branch permissions, offload complexity onto automation, support pre-push hooks
+
+check that you are a committer and the reviewer was a reviewer etc.
+
+we want rebase and merge button to work
+
+normally what the button does will rebase pull-request onto main, merge, and update the main ref
+
+but it doesn't allow us to run any tests
+
+we;re going to have a cq-main branch
+
+when you generate you're pull-request it will be against the cq branch
+
+it allow us to protect main
+
+bots will then cherry-pick from cq-main onto main
+
+its going to test and then merge onto main
+
+there is complexity, but we think the complexity is handled by the cq not the engineers
+
+yes, there are some race conditions, but that is part of git and we think the bots will be able to handle it with retry
+
+delayed tree, what happens if someone has a pull request coming from that delayed tree
+
+the delayed tree is the same as the protected tree, so the way the rebase and merge tree will work for pull requests
+
+is that there are two cq branches, one from both trees,
+
+the delayed branch will cherry-pick to cq main, if that works we're good
+
+if that doesn't then they will need to get accessor, or wait - we expect that to not be very common
+
+## Q&A
+
+maciej: 1 how will the tierataction between the protected tree and personal forks work? will our personAL Tree be protected
+
+Jonathan: believes the tooling will support this, a faked repo by default has the same protection as the upstream branch. He needs to check
+
+Sam: you won't even be able to make it public
+
+Jonatahn: delayed tree won't be a fork according to github
+
+maciej: so there isn't an easy way to make your personal fork public?
+
+that a downside than if your branches lived in the main tree
+
+having dev branches be secret forever is a weird side effect of the protected tree
+
+Jonathan: current safari tree has a lot of stale branches which is the downside to having dev branches in the main tree
+
+maciej: as a GitHub newbie, is scared of having multiple upstream but hopefully the tooling hides all that
+
+maciej: speaking of wrappers
+
+webkit-patch is svn designed but it would be good to make the sub commands work with git, to keep the workflow seems like an advantage than migrating to a different tool with different commands
+
+Jonathan: webkit-patch does a lot more than most people realize, it is possible to migrate some commands with obvious parallels.
+
+maciej: ok to deprecate obscure functionality seems unnecessary to change command line interface
+
+maciej: favorite thing is the thing that makes the bug and pull request all at once
+
+one other thing the term pfr is weird, but its a pull request not a patch, that term could be confusing
+
+I do hope that most of the tools that do stuff should have minimal output
+
+git tends to be spammy
+
+Myles; our developers that are committers going to be prohibited from landing manually
+
+Jonathan: we are going to be moving to a cq only world
+
+if we don't there is no way to enforce anything on main
+
+we are creating a fast cq
+
+the only thing that branch will do will be the minimal checks so you can land without waiting too long
+
+Jonathan: in this world being a committer means you have access to the cq branch
+
+maciej: one thought, the fast path should have a scary name and be obscure
+
+cq its semantics are meant to be a queue, but its a stack, that has a lot of rebasing. will landing onto the commit queue squash or rebase
+
+Jonathan: rebase, this isn't any worse than how cq already works
+
+maciej: what happens if fast path cq introduces a conflict, is cq now broken
+
+maciej: can things from the cq land out of order?
+
+Jonathan: yes
+
+Jonathan: it sounds scary but these are problems the current cq already has
+
+maciej: because new cq is a branch and not just a patch it might have additional failure points
+
+Jonathan it is possible
+
+Alexey: needs to rethought because we are going to need more than on cq.
+
+one cq
+
+Jonathan: the design im thinking about has a lot of cherry picking but should allow for more than one cq bot
+
+maciej: this adds a lot of complexity we should be sure the big green button is worth it
+
+Mickhail: are we rewriting history?
+
+Jonathan cq patches will be constantly rewritten
+
+when we grab delayed patch if will be removed and moved to protected cq. if it fails cq it will go back to the pull request say you failed and reopen it
+
+Keith: is their a plan in place when we start switching over to go back if there are problems?
+
+Jonathan: when GitHub is the source of truth switching back will be difficult. during the transition we will bring up the cq on GitHub. and that could be switched from GitHub push to main vs. git svn commit easily
+
+if we really founds ourselves in a spot of trouble we could dcommit each patch as we go through
+
+svn won't handle all git patches
+
+Keith: we should do both in parallel for a couple months
+
+

--- a/Sources/WebKit/WebKit.docc/Other/ContributorMeetings/2021/2021IgaliaUpdate.md
+++ b/Sources/WebKit/WebKit.docc/Other/ContributorMeetings/2021/2021IgaliaUpdate.md
@@ -1,0 +1,39 @@
+# WebKit 2021/2022 Igalia
+
+## Overview
+
+Speaker : Brian Kardell
+
+Slides available [here](https://www.slideshare.net/igalia/2021-webkit-contributors-meeting-igalia).
+
+## Q&A
+
+q form ken russell: do you plan to look at rAf for workers?
+
+chris lord: IT is implemented, yes.
+
+jon willander: I am intersted in cookies.. As we know the implementation differs in ports. There are some new requests in HTTP... do you have requests/bugs? Would you be willing to work with us on that spec?
+
+adrian: I think we have not had terrible amounts of compat issues or bugs. But, I think it hasn't been a lot... Maybe patrick can comment?
+
+john w: Cookies have been traditionally seen as a pure state mechanism, but there has now been something about context and, for example partitioning per origin or per site
+
+Michael C: While we haven't had a lot of issues, when we do have them it is where we differ from the other browsers, I'm sure that the developers of libsoup would be interested in aligning... I think the cookie spec changes are quite complicated
+
+john w: cookies are never easy
+
+Michael C: More collaboration is definitely good in helping us understand
+
+Jigen Zhou: Can you say more about the SVG improvements?
+
+Brian K: There is a break out / talk on that later, Niko is going to give... Is there anything to say in summary?
+
+Brian K: Is there any thoughts on the webauthn2?
+
+maciej: apple has plans and goals here? What is the specific issue
+
+@othermaciej ​https://webkit.slack.com/archives/G0187FE66SH/p1631555347003700
+
+john w: Thoughts on the bird proposals/etc in the ad space
+
+brian k: we haven't had specific discussions on each of them, except perhaps some particular issues about some google things - nothing I am prepared to comment on well here... curious for your thoughts

--- a/Sources/WebKit/WebKit.docc/Other/ContributorMeetings/2021/2021OffscreenCanvas.md
+++ b/Sources/WebKit/WebKit.docc/Other/ContributorMeetings/2021/2021OffscreenCanvas.md
@@ -1,0 +1,39 @@
+# Offscreen Canvas 2021 Update
+
+## Overview
+
+Speaker : Chris Lord
+
+Slides available [here](https://cloud.igalia.com/s/GLHpqd5Y87tB4QY).
+
+## Q&A
+
+heycam: great work, I like it. I was curious what work needs to be done to bring this to apple ports, I am curious about (...gpu?)
+
+chris: Currently the GTK and WPE ports cannot use the GPU process... to do that would probably involve some pretty novel work, I don't know just off the top of my head
+
+myles: Such novel work probably wouldn't be port specific tho?
+
+chris: Yeah... I hope the way it is architected also means that i hope it wouldn't be impossibly hard.
+
+heycam: I guess in the GPU process we'd want to have parallel threads for the canvases doing work
+
+myles: this is really exciting, thumbsup
+
+chris: I'm really excited to see it land - at least the linux ports are more than a proof of concept at this point, there's certainly still work to do on the apple ports, but it's doable and we can help where we can
+
+cameron: Are there any parts that aren't done in the linux
+
+chris lord: I think that there is something like bitmap context - the feature that lets you get a canvas context for drawing to an image element? I think that is right? But as far as I know that doesn't work right now... For no particular reason, we just havent' worked on it
+
+imagebitmap basically works, there might be edges, we just haven't spent the time
+
+some things i'm not sure really - they are missing in the canvas implementation, we'll get it for free
+
+smfr: what about webgl context?
+
+chris l: yes, techically, but in linux we don't have the GPU process, and I think getting that to work wouldn't be entirely trivial
+
+myles: can I ask, what prompted you to work with?
+
+chris: really, it is just the thing I was tasked with when I came here... I have done things with async rendering and compositor in firefox in the past, so I have been working on graphics stuff for browsers for some time - and I dont' like to leave things half finished, so it got done

--- a/Sources/WebKit/WebKit.docc/Other/ContributorMeetings/2021/2021ProtectedCollaborationTree.md
+++ b/Sources/WebKit/WebKit.docc/Other/ContributorMeetings/2021/2021ProtectedCollaborationTree.md
@@ -1,0 +1,117 @@
+# Protected Collaboration Tree
+
+## Overview
+
+Speaker : Phil Pizlo
+
+## Talk
+
+Filip Pizlo: This is about how we close the source patch gap
+
+Black hats are mining our commits to find security fixes, and we want to stop that
+
+What is the source patch gap? Worst case (for Apple, possibly others) Landing a fix for a security bug is basically releasing an N-day
+
+No matter what the ship cadence is, there will be period of time that an attacker could see this commit and exploit it.
+
+The WebKit repository / trac/ changelogs are super valuable resouces for black hats to mine for N-days and weaponize them.
+
+Being more open with our non-Apple WK contributors
+
+If internal fuzzer teams find a security issue, to make it harder for black hats, we often don’t file a security bug, don’t mention it is a security bug, and don’t land the test case. We want to fix that.
+
+We want to do this without increasing costs. One option would be to have a separate repo that includes the fixes that are merged later.
+
+How will we address this while preserving existing workflows?
+
+We will have two GitHub repos, one that is public and read only. There will be another GitHub repo that is protected.
+
+The protected repo will be accessible by WebKit “Accessors”
+
+The protected repo will be replicated to the public repo with ~5 week delay
+
+For some test cases that we don’t want to share with people who don’t work on WebKit, we will have a separate test case GitHub repo (still thinking about who will have access, maybe the security group at minimum?)
+
+“Accessor” will be a new WebKit role
+
+All current committers will be grandfathered in, other requirements should be easy enough for those that are legitimately working on WebKit, but just expensive enough that black hats will not try to be come accessors.
+
+Proposal: 3 good commits in last 3 months Anyone vouched for by 3 accessors in the lsat 3 months Anyone whose patch got an “a+” in the last month Anyone vouched for by a security group member in the same organization as them Anyone working for an organization with 4+ reviewer accessors
+
+Accessors: can access restricted tree and (hopefully) the security test case tree, can post PRs against the restricted tree and request r?/cq?, acess lapses after 3 months of < 3 patches or no vouches
+
+Committers get the above, but can cq+ and commit directly, lapses after 6 months of inactivity
+
+Reviewers get the above, access lapses after 1 year of inactivity, can vouch for accessors and nominate accessors, committers, or reviewers
+
+Security group members can access restricted tree and test case tree, can access security bugs
+
+We think we can do this as part of the GitHub transition
+
+Outsiders can post PRs to public tree, an “a+” transitions the PR to the protected tree, but they can’t see the change for ~5 weeks.
+
+## Q&A
+
+Nikolas: This is an interesting concept, wondering about the transition. How does a patch posted against the public tree move over to the protected tree, especially if there are build failures? Do they have to fix them through shared logs?
+
+Filip: If you have a substantive patch, it can be marked as “a?” and a reviewer can provide the access via an “a+“, which will give access to the author for a month.
+
+Jonathan: When we’ve looked a who has been contributing and what they have been contributing recently, most drive-by contributions would probably merge fine on the delayed tree.
+
+Michael Catanzaro: have you thought about the implication for stable branches? We won’t want to wait five weeks between branching and these stable branches are public.
+
+Filip: We want to talk and understand this scenario more. The most valuable thing about access to the live tree right now is trac.webkit.org. There is a desire to continue publishing release branches with history at some point.
+
+Leo Balter: I’m not a frequent contributor to WebKit, I usually track features that are being worked on. What level of access do I need to keep doing that?
+
+Filip: You’d want to be an accessor. You’d have two paths: if anyone at your organization is a security group member you could get the access, or you get three reviewers to vouch for you.
+
+Xabier Rodríguez Calvar: Sometimes, for customers, we need to work on downstream repos that are public. What if I fix a sec bug and I want to land it upstream and then bring it back downstream? I guess I need to wait until it his the read-only or I’d be disclosing the protected repo, right? Would it be ok to backport patches that are not security bugs?
+
+Jonathan: Filip: If you fix a layout bug that doesn’t involve memory corruption in the layout engine, then you immediately ship it downstream then no harm no foul
+
+Michael: Thinking about the implications of this, I guess it means all the protected pull requests would have to be private forever because they would be in the private repo. Sometimes we need to ship security fixes sooner than five weeks
+
+Maciej: We haven’t thought through everything about pull requests, maybe we can migrate them to the public delayed repo
+
+Jonathan: that is harder because their numbers will change as you move them back and forth.
+
+Maciej: We’ve thought of something that works for Apple’s release cadence, but we don’t want to say no one is allowed to ship a security fix faster than Apple, that wouldn’t be good for users. We hope to speed up our cadence to the point where it is almost a moot point.
+
+Michael: I’m sure there will be a lot of discussion about this on webkit-dev since it is midnight in Europe right now and not everyone is here
+
+Michael: This will go a long way to stopping most of those have been exploiting the fixes, but NSO group people will probably still get through
+
+Tadeu: What will the workflow look like for external folks reporting security bugs
+
+Filip: We would still have the security component in bugzilla, so they can report there. The fix would land on the protected tree, so it should just work out.
+
+Jonathan: There will be things to consider when we switch to GitHub issues, but we aren’t doing that just yet.
+
+Dewei: What is the minimum cost if a hacker wants to get access to the repo?
+
+Filip: They would have to write a decent looking WebKit patch. My hope is that black hats would have to devote significant time to contribute to WebKit that they would rather do something else.
+
+Filip: There are two things that our current open source project enables aside from hackers finding N-days on trunk. It is possible that someone who is not working for an NSO group, like in infosec twitter sphere, they could notice a juicy bug fix on trac and tweet about it so it becomes extremely public.
+
+Mikhail: To confirm, we are talking about protecting source code, not the whole bug tracker. Jonathan: Bugzilla is currently our bug tracker and the place we do code review. In the next talk, we’ll talk about using GitHub’s pull request UI.
+
+Simon Fraser: If I were a state sponsored organization, I would find a student, encourage them to make contributions and become an accessor, then coerce them to give me their GitHub login, then it seems like we lose all the benefits of the protected tree.
+
+Filip: Feedback from Security architects I’ve talked to is that any state sponsored agency could coerce anyone who works for any of the organizations that are stakeholders in WebKit including Apple. I don’t have a feeling about how much harder it is for them to do that to an Apple engineer vs a student, but my understanding is that it’s close
+
+Simon: There is one way this model is more susceptible than our current model in that accessors will have access to the security test case repo
+
+Filip: That’s why we’re considering restricting access to security group members
+
+Simon: There would be three options for landing a security test, the protected GitHub repo, the security repo, the Apple internal repo, and that means extra burden on me to make the right decision
+
+Filip: Fair point, the test case repo would be most useful for fuzzer test cases.
+
+Maciej: The goal isn’t to prevent any super highly resourced and motivated organization from seeing the source code, but to add enough of a speedbump for those that use it as a practically free way to find exploits.
+
+Filip: The scary thing is that if you have a well engineered exploit chain that has a part that gets closed by a software update all you have to do is look at trac.webkit.org and a day later you’ve got a replacement. This will hopefully make it more than a day.
+
+SF Akihabara (Sony): It sounds like this is adding a lot of pain for engineers. Is there any way to automate this or have a branch downstream that applies patches and rebase
+
+Jonathan: the explanation of this process is more confusing than what it will be in practice. Apple does a lot of cherry picking, rebasing, and merging, and the has a very high cost on the people that are writing the security fixes. Security fixes tend to touch code other people are working on


### PR DESCRIPTION
<pre>
Add 2021 Contributor Meeting Talk/Q&A Notes

This adds the available 2021 Contributor Meeting Talk/Q&A notes. I noticed quite a few of the Q&A sessions are missing, so I was only able to add 5 of them.
</pre>

