### PR TITLE
Improve README build and import instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,22 @@ This will bring up a local web server, so you can view the documentation locally
 make preview
 ```
 
-### Docc Archive (Xcode)
+### DocC Archive (Xcode)
 
 Generate a DocC Archive that will be automatically imported into Xcode's documentation.
 
 ```
 make docc
+```
+
+#### Build DocC Archive in Xcode
+
+Generate a DocC Archive in Xcode. This documentation will be available under the Workspace Documentation section.
+You will need to export `WebKit` and import it to add the DocC Archive to the Imported Documentation section.
+
+```
+Open Package.swift
+Product -> Build Documentation (⌃⇧⌘D)
 ```
 
 ### GitHub Release
@@ -30,5 +40,5 @@ make github
 
 ## Import Documentation into Xcode
 
-Open `WebKit.doccarchive` and it will be automatically be imported into Xcode.
-Running `make docc` will also launch Xcode and import the document.
+Open `WebKit.doccarchive` and the documentation will be automatically imported into Xcode under the Imported Documention section.
+When running `make docc` the documentation will automatically be imported into Xcode.


### PR DESCRIPTION
<pre>
Improve README build and import instructions

Add a section on building the documentation in Xcode. 
Also, cleaned up the import documentation into Xcode section.

* README.md
</pre>

