### PR TITLE
Address Lightmode search bar placeholder

### DIFF
--- a/docs/stylesheets/webkit.css
+++ b/docs/stylesheets/webkit.css
@@ -1930,6 +1930,7 @@ article blockquote {
 ::placeholder {
     font-size: 1em;
     padding: 5px;
+    visibility: hidden;
   }
 
 .md-search__form {


### PR DESCRIPTION
The light mode search bar placeholder "Search" was causing a lot of issues with rendering to light. This hides it for now.

