### PR TITLE
Improve styling to match webkit.org, and not re-stlye the world

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,8 @@
+---
+hide:
+  - navigation
+---
+
 # WebKit Overview
 
 WebKit is a cross-platform web browser engine. On iOS and macOS, it powers Safari, Mail, iBooks, and many other applications.

--- a/docs/stylesheets/webkit.css
+++ b/docs/stylesheets/webkit.css
@@ -1,3 +1,4 @@
+/* Set Light Mode Colors */
 :root {
     --background-color: hsl(203.6, 100%, 12%);
     --link-color: hsl(200, 100%, 40%);
@@ -117,6 +118,7 @@
     --code-selection-background-color: hsl(212.3, 97.8%, 81.8%);
 }
 
+/* Set Dark Mode Colors */
 @media(prefers-color-scheme:dark) {
     :root {
         --background-color: hsl(203.6, 100%, 12%);
@@ -237,1751 +239,181 @@
     }
 }
 
-/** Resets **/
-html, body, div, span, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, samp,
-small, strike, strong, sub, sup, tt, var,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details,
-figure, figcaption, footer, header, hgroup,
-menu, nav, output, section, summary,
-time, mark, audio, video {
-    margin: 0;
-    padding: 0;
-    border: 0;
-    font: inherit;
-    vertical-align: baseline;
+/* Override MkDocs Material colors with WebKit color scheme  */
+:root {
+    --md-primary-fg-color: var(--background-color);
+    --md-primary-fg-color--light: var(--button-background-color);
+    --md-primary-fg-color--dark: var(--tile-background-color);
+
+    --md-accent-fg-color: var(--link-color);
+    --md-accent-fg-color--transparent: var(--router-background-hover-color);
+
+    --md-default-fg-color: var(--text-color);
+    --md-default-fg-color--light: var(--text-color-heading);
+    --md-default-fg-color--lighter: var(--text-color-medium);
+    --md-default-fg-color--lightest: var(--text-color-light);
+    --md-default-bg-color: var(--content-background-color);
+
+    --md-code-fg-color: var(--code-text-color);
+    --md-code-bg-color: var(--code-background-color);
+    --md-footer-fg-color--light: var(--inverse-text-color);
+    --md-footer-fg-color--lighter: var(--inverse-text-color);
+
+    --md-code-hl-number-color: var(--syntax-color-number);
+    --md-code-hl-special-color: var(--syntax-color-builtin);
+    --md-code-hl-function-color: var(--syntax-color-identifier);
+    --md-code-hl-constant-color: var(--syntax-color-builtin);
+    --md-code-hl-keyword-color: var(--syntax-color-keyword);
+    --md-code-hl-string-color: var(--syntax-color-string);
+    --md-code-hl-name-color: var(--syntax-color-identifier);
+    --md-code-hl-operator-color: var(--syntax-color-operator);
+    --md-code-hl-punctuation-color: var(--syntax-color-keyword-operator);
+    --md-code-hl-comment-color: var(--syntax-color-comment);
+
+    --md-typeset-a-color: var(--link-color);
+
+    --md-footer-bg-color: var(--background-color);
+    --md-footer-fg-color: var(--text-color);
+
+    --md-primary-bg-color: var(--inverse-text-color);
 }
-/* HTML5 display-role reset for older browsers */
-article, aside, details, figcaption, figure,
-footer, header, hgroup, menu, nav, section {
-    display: block;
-}
+
+/* font-size is wrecking havoc between WebKit and MkDocs Material theming.
+   WebKit assumes font-size at 62.5%, while MkDocs Material gives a more variable theming between 125% - 150% 
+   https://github.com/squidfunk/mkdocs-material/blob/f08bbb4dece0e7229de3d8f11f0eeaf5231d5424/src/assets/stylesheets/main/components/_base.scss#LL31C3-L31C3.
+
+   So we need to redo a lot of the calculations on the WebKit side.
+*/
 html {
-    font-family: -apple-system, "SF Pro Text", Helvetica, sans-serif;
     font-synthesis: none;
+    font-size: 125%;
 }
+
 body {
-    font-size: 1.7rem;
-    font-weight: 400;
-    line-height: 1.52947;
-    letter-spacing: -0.021rem;
-    background-color: hsl(203.6, 100%, 12%);
-    background-color: var(--background-color);
-    color: hsl(0, 0%, 20%);
+    --md-text-font-family: -apple-system, "SF Pro Text", "Helvetica", sans-serif;
+    --md-code-font-family: "SF Mono", "Menlo", monospace;
+    -webkit-font-smoothing: antialiased;
+    font-feature-settings: normal;
+}
+
+/* Override Main Article Options */
+.md-typeset,
+.md-search-result .md-typeset {
     color: var(--text-color);
-}
-ol, ul {
-    list-style: none;
-}
-dl {
-    margin: 2rem 0;
-}
-dt {
-    font-weight: bold;
-}
-dd {
-    margin: 0 3rem;
-}
-blockquote, q {
-    quotes: none;
-}
-blockquote:before, blockquote:after,
-q:before, q:after {
-    content: '';
-    content: none;
-}
-table {
-    border-collapse: collapse;
-    border-spacing: 0;
-}
-p:empty {
-    display: none;
-}
-a {
-    text-decoration: none;
-    transition: color 500ms cubic-bezier(0.190, 1.000, 0.220, 1.000); /* ease-out-exponential */
-}
-a:hover {
-    text-decoration: underline;
-}
-a,
-a > code,
-a[name]:hover {
-    color: hsl(200, 100%, 40%);
-    color: var(--link-color);
-}
-
-h1 a:hover {
-    text-decoration: none;
-}
-hr {
-    border: none;
-    border-bottom: 1px solid hsl(0, 0%, 86.7%);
-    border-bottom-color: var(--horizontal-rule-color);
-}
-strong {
-    font-weight: 600;
-}
-em {
-    font-style: italic;
-    font-weight: 300;
-}
-sup {
-    vertical-align: super;
-    font-size: smaller;
-    line-height: 1;
-}
-code {
-    font-family: "SF Mono", "Menlo", monospace;
-    font-size: 80%;
-    padding: 0 0.5rem;
-    border-radius: 2px;
-    border: 1px solid hsl(0, 0%, 90.6%);
-    border-color: var(--code-border-color);
-    background-color: hsl(0, 0%, 94.9%);
-    background-color: var(--code-background-color);
-    color: hsl(0, 0%, 26.7%);
-    color: var(--code-text-color);
-}
-
-main {
-    background-color: hsl(0, 0%, 96.9%);
-    background-color: var(--content-background-color);
 }
 
 .md-typeset {
-    font-size: 1.3rem;
+    text-rendering: optimizeLegibility;
+    font-kerning: auto;
+    font-style: normal;
+    -webkit-print-color-adjust: economy;
 }
 
-/** Accessibility Helpers **/
-a[name] {
-    display: inline-block;
-    position: relative;
-    top: -3rem;
-    color: hsl(0, 0%, 86.7%);
-    color: var(--text-color-light);
-    width: 0;
-    text-decoration: none;
+.md-content .md-typeset {
+    font-size: 0.85rem;
 }
 
-p > a[name]::before {
-    content: "#";
-    margin-left: -1.7rem;
-    position: relative;
-    top: 3rem;
-    color: hsl(240, 2.3%, 56.7%);
-    color: var(--text-color-coolgray);
-    transition: color 500ms cubic-bezier(0.190, 1.000, 0.220, 1.000), opacity 500ms ease-in; /* ease-out-exponential */
-    opacity: 0.3;
+.md-content .md-typeset h1 {
+        font-size: 2.8rem;
+        font-weight: 500;
+        margin-bottom: 1.5rem;
+        margin-top: -0.4rem;
+        text-align: center;
+        letter-spacing: 0.002rem;
+    }
+
+.md-content .md-typeset h2 {
+        font-size: 1.6rem;
+        line-height: 1.09375;
+        font-weight: 500;
+        margin-top: 2rem;
+        margin-bottom: 0.5rem;
+        letter-spacing: -0.0055rem;
 }
 
-a[name]:hover {
-    text-decoration: none;
+.md-content .md-typeset h3 {
+        font-size: 1.2rem;
+        line-height: 1.09375;
+        font-weight: 500;
+        letter-spacing: -0.0055rem;
 }
 
-a[name]:hover::before {
-    color: hsl(200, 100%, 40%);
-    color: var(--link-color);
+.md-content .md-typeset h4 {
+        font-size: 1.1rem;
+        line-height: 1.09375;
+        font-weight: 500;
 }
 
-p:hover > a[name]::before {
-    opacity: 1;
+.md-content .md-typeset h5 {
+        font-size: 1rem;
+        line-height: 1.09375;
+        font-weight: 500;
 }
 
-
-/** Code Syntax Highlighting **/
-pre {
-    width: calc(100% + 6rem);
-    overflow: auto;
-    -webkit-overflow-scrolling: touch;
-    background-color: hsl(0, 0%, 94.9%);
-    background-color: var(--code-background-color);
-    border: 1px solid hsl(0, 0%, 90.6%);
-    border-color: var(--code-border-color);
-    border-radius: 2px;
-    box-sizing: border-box;
-    padding: 3rem;
-    margin-left: -3rem;
-}
-
-code {
-    color: hsl(0, 0%, 26.7%);
-    color: var(--code-text-color);
-    font-size: 1.6rem;
-    line-height: 2.5rem;
-}
-
-pre code {
-    border: none;
-    padding: 0;
-}
-
-code .keyword,
-code.html .tag {
-    color: hsl(292.5, 100%, 26.7%);
-    color: var(--syntax-color-keyword);
-}
-code .keyword.builtin,
-code .keyword.literal {
-    color: hsl(309.6, 85.8%, 35.9%);
-    color: var(--syntax-color-builtin);
-}
-code .keyword.type {
-    color: hsl(17.6, 80.4%, 44.1%);
-    color: var(--syntax-color-keyword-type);
-}
-code .preprocessor {
-    color: hsl(60, 20%, 50%);
-    color: var(--syntax-color-preprocessor);
-}
-code .comment {
-    color: hsl(180, 6.9%, 60.4%);
-    color: var(--syntax-color-comment);
-    float: none;
-    display: inline;
-}
-code .comment .doc {
-    color: hsl(186.3, 8.3%, 55.1%);
-    color: var(--syntax-color-comment-doc);
-    font-weight: bold;
-}
-code .identifier {
-    color: hsl(209.6, 71.4%, 38.4%);
-    color: var(--syntax-color-identifier);
-}
-code .string,
-code .char {
-    color: hsl(70.8, 93%, 22.4%);
-    color: var(--syntax-color-string);
-}
-code .escaped {
-    color: hsl(0, 0%, 66.7%);
-    color: var(--syntax-color-escaped);
-}
-code .number,
-code .tag {
-    color: hsl(194.5, 14.1%, 40.2%);
-    color: var(--syntax-color-number);
-}
-code .regex,
-code .attribute {
-    color: hsl(44.8, 53.2%, 33.5%);
-    color: var(--syntax-color-attribute);
-}
-code .attribute.value {
-    color: hsl(1.4, 79.8%, 42.7%);
-    color: var(--syntax-color-attribute-value);
-}
-code .operator {
-    color: hsl(0, 0%, 53.3%);
-    color: var(--syntax-color-operator);
-}
-code .keyword.operator {
-    color: hsl(357.5, 100%, 33.1%);
-    color: var(--syntax-color-keyword-operator);
-}
-code .whitespace {
-    background-color: hsl(0, 0%, 20%);
-    background-color: var(--syntax-color-whitespace-background-color);
-}
-code .error {
-    border-bottom: 1px solid hsl(0, 100%, 50%);
-    border-color: var(--syntax-color-error-border);
-}
-code .doctype {
-    color: hsl(0, 0%, 75.3%);
-    color: var(--syntax-color-doctype);
-}
-code .property {
-    color: hsl(295.7, 76.8%, 32.2%);
-    color: var(--syntax-color-property);
-}
-
-code.xml .comment,
-code.html .comment {
-    color: hsl(120, 100%, 22.7%);
-    color: var(--syntax-color-xml-comment);
-}
-
-code.xml .preprocessor .keyword {
-    color: hsl(60, 20%, 50%);
-    color: var(--syntax-color-preprocessor);
-}
-code.xml .meta,
-code.xml .meta .keyword {
-    color: hsl(180, 50%, 40%);
-    color: var(--syntax-color-xml-meta);
-}
-
-code.cpp .preprocessor .identifier {
-    color: hsl(60, 20%, 50%);
-    color: var(--syntax-color-preprocessor);
-}
-
-pre::-moz-selection,
-pre span::-moz-selection {
-    background-color: hsl(212.3, 97.8%, 81.8%);
-    background-color: var(--code-selection-background-color);
-}
-
-pre::selection, pre span::selection {
-    background-color: hsl(212.3, 97.8%, 81.8%);
-    background-color: var(--code-selection-background-color);
-}
-
-code.syntax { white-space: normal; }
-code.syntax .newlines { white-space: pre; display: block; }
-
-code.css .attribute,
-code.css .identifier,
-code.css .preprocessor {
-    color: hsl(309.6, 85.8%, 35.9%);
-    color: var(--syntax-color-css-property);
-}
-
-code.css .keyword {
-    color: hsl(0, 0%, 0%);
-    color: var(--syntax-color-css-selector);
-}
-code.css .number {
-    color: hsl(248.1, 100%, 40.6%);
-    color: var(--syntax-color-css-number);
-}
-
-/** Post Typography **/
-
-main {
-    font-size: 200%;
-    width: 100vw;
-    max-width: 100%;
-    overflow-x: hidden;
-    box-sizing: border-box;
-    padding: 3rem 0 0;
-}
-
-article {
-    padding-bottom: 3rem;
-}
-
-article::after {
-    clear: both;
-    content: ' ';
-    display: table;
-}
-
-main h1 {
-    text-align: left;
-}
-
-main h1,
-article h1,
-article h1 a {
-    margin: 0 auto 3rem;
-    font-size: 5.6rem;
-    font-weight: 500;
-    letter-spacing: 0.004rem;
-    line-height: 1.10746;
-    text-align: center;
-    text-decoration: none;
-    color: hsl(0, 0%, 26.7%);
-    color: var(--text-color-heading);
-}
-
-article h2 {
-    font-size: 3.2rem;
-    line-height: 1.09375;
-    font-weight: 500;
-    letter-spacing: -0.011rem;
-    margin: 4rem 0 1rem;
-}
-
-article h3 {
-    font-size: 2.4rem;
-    line-height: 1.09375;
-    font-weight: 500;
-    letter-spacing: -0.011rem;
-}
-
-article h4 {
-    font-size: 2.2rem;
+.md-content .md-typeset h6 {
+    font-size: 0.85rem;
     line-height: 1.09375;
     font-weight: 500;
 }
 
-article h5 {
-    font-size: 2rem;
-    line-height: 1.09375;
-    font-weight: 500;
-}
-
-article h6 {
-    font-size: 1.7rem;
-    line-height: 1.09375;
-    font-weight: 500;
-}
-
-article h3,
-article h4,
-article h5,
-article h6 {
-    margin-bottom: 0.5rem;
-}
-
-article h2 + h3,
-article h3 + h4,
-article h4 + h5,
-article h5 + h6 {
-    margin-top: 0;
-}
-
-article p,
-article div > img,
-article pre,
-article hr {
-    margin-bottom: 3rem;
-}
-
-article .byline p {
-    font-size: 1.5rem;
-    line-height: 3rem;
-    margin-bottom: 0;
-    color: hsl(240, 2.3%, 56.7%);
-    color: var(--text-color-coolgray);
-}
-
-article .byline .date {
-    font-weight: 900;
-}
-
-article .byline .author {
-    white-space: nowrap;
-
-}
-
-article table {
-    font-size: 1.6rem;
-    border-collapse: collapse;
-    border-spacing: 0;
-    margin: 3rem 0;
-    width: 100%;
-}
-
-article thead, article tfoot {
-    border-top: 1px solid hsl(0, 0%, 73.3%);
-    border-top-color: var(--table-top-rule-color);
-    border-bottom: 1px solid hsl(0, 0%, 87.8%);
-    border-bottom-color: var(--table-rule-color);
-}
-
-article tr {
-    border-top: 1px solid hsl(0, 0%, 87.8%);
-    border-color: var(--table-rule-color);;
-}
-
-article tr:first-child {
-    border-top: 0 none;
-}
-
-article th {
-    font-weight: bold;
-    vertical-align: bottom;
-    text-align: left;
-
-}
-article td, th {
-    padding: 1.754386%;
-}
-article th:first-child {
-    padding-left: 0;
-}
-
-article ol,
-article ul {
-    padding-left: 3rem;
-    margin: 3rem 0;
-}
-
-article ol {
-    list-style-type: decimal;
-}
-
-article ul {
-    list-style-type: square;
-}
-
-article ul ul,
-article ul ol,
-article ol ul,
-article ol ol {
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-article blockquote {
-    width: 100vw;
-    height: auto;
-    padding: 0 3rem;
-    left: 50%;
-    position: relative;
-    margin-left: -50vw;
-    box-sizing: border-box;
-    font-weight: 200;
-    font-size: 3rem;
-    line-height: 4.2rem;
-    text-align: center;
-    color: hsl(240, 2.3%, 56.7%);
-    color: var(--text-color-coolgray);
-}
-article blockquote > * {
-    max-width: 1140px;
-    margin-left: auto;
-    margin-right: auto;
-}
-
-article blockquote:first-child {
-    width: 100%;
-    text-align: left;
-    margin: 0 auto;
-    left: 0;
-    padding: 0;
-}
-
-.post .bodycopy > p:last-child:after {
-    content: " \220E"; /* Tombstone */
-    color: hsl(0, 0%, 33.3%);
-    color: var(--text-color-medium);
-}
-
-article div.note {
-    margin-left: -3rem;
-    margin-right: -3rem;
-    padding: 3rem;
-    background-color: hsl(50, 100%, 94%);
-    background-color: var(--note-background-color);
-    border: 1px solid hsl(40, 100%, 90%);
-    border-color: var(--note-border-color);
-    color: hsl(30, 90%, 35%);
-    color: var(--note-text-color);
-    border-radius: 3px;
-    margin-bottom: 3rem;
-    box-sizing: normal;
-}
-
-article .foreword {
-    padding: 1.6rem 2.2rem 1.6rem;
-    line-height: 2.6rem;
-    background-color: hsl(0, 0%, 94.1%);
-    background-color: var(--foreword-background-color);
-    border: 1px solid hsl(0, 0%, 90.2%);
-    border-color: var(--foreword-border-color);
-    color: hsl(240, 2.3%, 56.7%);
-    color: var(--foreword-text-color);
-    border-radius: 3px;
-    margin-bottom: 3rem;
-    box-sizing: normal;
-    font-size: 1.6rem;
-    font-style: italic;
-}
-
-article .meta {
-    clear: both;
-}
-
-article .meta .written {
-    margin-bottom: 1em;
-}
-
-article .meta .written,
-article .meta .updated {
-    text-align: right;
-    font-size: 1.2rem;
-    font-style: italic;
-    text-transform: uppercase;
-}
-
-article .meta .icon {
-    float: left; 
-    margin-right: 1em;
-}
-
-article .two-columns {
-    columns: 2;
-    column-gap: 6rem;
-    margin: 3rem 0;
-}
-
-article .two-columns h2,
-article .two-columns h3,
-article .two-columns h4,
-article .two-columns h5,
-article .two-columns h6 {
-    break-after: avoid-column; /* https://bugs.webkit.org/show_bug.cgi?id=148814 */
-}
-
-article .two-columns p {
-    break-inside: avoid-column;
-}
-
-/** Post Layout **/
-
-article .byline {
-    float: left;
-    width: 191px;
-    text-align: right;
-    padding-right: 4rem;
-    box-sizing: border-box;
-}
-
-article .bodycopy,
-article .meta {
-    width: 66%;
-    margin: 0 auto;
-    position: relative;
-}
-
-article .aligncenter .wp-caption-text {
-    right: -50%;
-}
-
-article .alignleft {
-    float: left;
-    margin: 1.5rem 1.5rem 1.5rem 0;
-}
-
-article .aligncenter {
-    clear: both;
-    display: block;
-    margin: 0 auto 3rem;
-}
-
-article div.aligncenter {
-    position: relative;
-    float: right;
-    right: 50%;
-}
-
-article div.aligncenter img {
-    position: relative;
-    right: -50%;
-}
-
-article .alignright {
-    float: right;
-    margin: 1.5rem 0 1.5rem 1.5rem;
-}
-
-article .alignnone {
-    display: block;
-    float: none;
-}
-
-article .alignnone.size-full {
-    width: 100vw;
-    height: auto;
-    left: 50%;
-    position: relative;
-    -webkit-transform: translate(-50vw, 0);
-    transform: translate(-50vw, 0);
-}
-
-article .abovetitle {
-    margin-top: -0.4em;
-}
-
-article .pull-left {
-    float: left;
-    margin: 1.5rem 1.5rem 1.5rem -25%;
-}
-
-article .pull-right {
-    float: right;
-    margin: 1.5rem -25% 1.5rem 1.5rem;
-}
-
-article .cliptop {
-    border-top: 1px solid hsl(0, 0%, 86.7%);
-    border-color: var(--horizontal-rule-color);
-}
-
-article .clipbottom {
-    border-bottom: 1px solid hsl(0, 0%, 86.7%);
-    border-color: var(--horizontal-rule-color);
-}
-
-article .clipright {
-    border-right: 1px solid hsl(0, 0%, 86.7%);
-    border-color: var(--horizontal-rule-color);
-}
-
-article .clipleft {
-    border-left: 1px solid hsl(0, 0%, 86.7%);
-    border-color: var(--horizontal-rule-color);
-}
-
-article .mattewhite {
-    background-color: hsl(0, 0%, 100%);
-    background-color: var(--figure-mattewhite-background-color);
-    border-top: 1px solid hsl(0, 0%, 90.6%);
-    border-bottom: 1px solid hsl(0, 0%, 90.6%);
-    border-color: var(--article-border-color);
-    padding-top: 3rem;
-    padding-bottom: 3rem;
-}
-
-.image {
-    padding: var(--image-padding) var(--image-padding) 0;
-    --image-padding: 0.5em;
-}
-
-p .image,
-li .image {
-    --image-padding: 0;
-}
-
-.image.block {
-    display: block;
-}
-
-.image img {
-    border-color: hsl(0, 0%, 90.6%);
-    border-color: var(--article-border-color);
-    border-style: solid;
-    border-width: 0px;
-}
-
-.widescreen .image {
-    display: inline-block;
-}
-
-.image.slice-top > picture > img {
-    border-top-width: 1px;
-}
-
-.image.slice-right > picture > img {
-    border-right-width: 1px;
-}
-
-.image.slice-bottom > picture > img {
-    border-bottom-width: 1px;
-}
-
-.image.slice-left > picture > img {
-    border-left-width: 1px;
-}
-
-.flex {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    margin-top: 1em;
-}
-
-.flex.center {
-    justify-content: center;
-}
-
-article .mattewhite:not(.widescreen) {
-    border: 1px solid hsl(0, 0%, 90.6%);
-    border-color: var(--article-border-color);
-    padding: 3rem;
-    margin-left: -3rem;
-    margin-right: -3rem;
-}
-
-article .mattewhite.tightwad {
-    padding: 0;
-}
-
-/** Article Figures **/
-
-article figure {
-    margin-bottom: 3rem;
-    text-align: center;
-}
-article figure > img {
-    display: inline-block;
-    max-width: 100%;
-    max-height: 540px;
-    height: auto;
-    width: auto;
-}
-
-figure.widescreen {
-    position: relative;
-    width: 100vw;
-    left: 50%;
-    transform: translate(-50%);
-    clear: both;
-}
-
-figure.widescreen img,
-figure.widescreen figcaption {
-    display: block;
-    margin: 0 auto;
-}
-
-figure.widescreen figcaption {
-    margin-top: 3rem;
-}
-
-figure.widescreen video {
-    max-height: 420px;
-    max-width: 66%;
-}
-
-figure.table {
-    -webkit-overflow-scrolling: touch;
-    width: calc(100% + 6rem);
-    overflow: auto;
-    border: 1px solid hsl(0, 0%, 90.6%);
-    border-color: var(--code-border-color);
-    background-color: hsl(0, 0%, 94.9%);
-    background-color: var(--code-background-color);
-    border-radius: 3px;
-    box-sizing: border-box;
-    padding: 3rem;
-    margin-left: -3rem;
-}
-
-article picture {
-    max-width: 100%;
-}
-
-article picture > img {
-    max-width: 100%;
-    max-height: 100%;
-}
-
-
-article video.alignleft,
-article video.alignright {
-    max-width: 50%;
-}
-
-article .alignleft:first-child,
-article .alignright:first-child {
-    margin-top: 0.5rem;
-    margin-bottom: 0.5rem;
-}
-
-article figcaption {
-    text-align: left;
-    margin-top: 1.5rem;
-    line-height: 1.5;
-    max-width: 970px;
-    padding-left: 1.5rem;
-    box-sizing: border-box;
-    font-size: 1.3rem;
+.md-content .md-typeset p {
+    font-size: 0.85rem;
     font-weight: 400;
-    color: hsl(0, 0%, 33.3%);
-    color: var(--text-color-medium);
-    position: relative;
+    font-feature-settings: normal;
+    letter-spacing: -0.0105rem;
+    margin-top: 0.75px;
+    margin-bottom: 0.75rem;
 }
 
-article figcaption::before {
-    left: 1.5rem;
-    width: 15%;
-    height: 100%;
-    bottom: 2.5rem;
-    border-top: 1px solid hsl(0, 0%, 80%);
-    border-color: var(--figure-caption-rule-color);
-    content: '';
-    opacity: 1;
-    display: inline-block;
-    box-sizing: border-box;
-    position: absolute;
+.md-content pre {
+    margin-left: -1.1rem;
+    margin-bottom: 1.5rem;
+    border-radius: 2px;
+    border: 1px solid var(--code-border-color);
 }
 
-figure.aligncenter figcaption {
-    text-align: center;
-    padding-left: 0;
+.md-content .md-typeset code {
+    font-size: .85rem;
+    line-height: 1.25rem;
 }
 
-figure.aligncenter figcaption::before {
-    margin: 0 auto;
-    width: 20%;
-    left: 50%;
-    transform: translate(-50%);
-}
-
-article .clipbottom + p + figcaption {
-    margin-top: 1rem;
-}
-
-article .clipbottom + p + figcaption::before {
-    width: 0;
-}
-
-/** Page Layout **/
-article.page h1 {
-    text-align: left;
-    width: 66%;
-}
-
-.page .bodycopy h1 {
-    width: 100%;
-}
-
-/** Web Inspector Pages **/
-.single-web_inspector_page .landing-link {
-    display: block;
-    text-align: left;
-    font-size: 1.3rem;
-    text-transform: uppercase;
-    color: var(--link-color);
-    color: hsl(200, 100%, 40%);
-    margin-bottom: 0;
-}
-
-.single-web_inspector_page .landing-link:hover {
+.md-typeset a:hover {
     text-decoration: underline;
 }
 
-/** Load Effects **/
-
-@keyframes fade-in {
-    from {
-        opacity: 0;
-    }
-
-    to {
-        opacity: 1;
-    }
+tr {
+    font-size: 0.85rem;
 }
 
-@-webkit-keyframes fade-in {
-    from {
-        opacity: 0;
-    }
-
-    to {
-        opacity: 1;
-    }
-}
-
-@keyframes fade-in-move-down {
-    from {
-        opacity: 0;
-        -webkit-transform: translateY(-3rem);
-        transform: translateY(-3rem)
-    }
-
-    to {
-        opacity: 1;
-        -webkit-transform: translateY(0);
-        transform: translateY(0)
-    }
-}
-
-@-webkit-keyframes fade-in-move-down {
-    from {
-        opacity: 0;
-        -webkit-transform: translateY(-3rem);
-        transform: translateY(-3rem)
-    }
-
-    to {
-        opacity: 1;
-        -webkit-transform: translateY(0);
-        transform: translateY(0)
-    }
-}
-
-article,
-.feature-status-page {
-    -webkit-animation: fade-in-move-down 0.7s;
-    animation: fade-in-move-down 0.7s;
-}
-
-.tile {
-    -webkit-animation: fade-in 0.4s;
-    animation: fade-in 0.4s;
-}
-
-/** Page Table of Contents **/
-
-.table-of-contents {
-    float: right;
-    box-sizing: border-box;
-    padding: 2.5rem 0 0 0;
-    margin: 0 0 2.5rem 3rem;
-
-    max-width: 33%;
-    z-index: 5;
-    font-size: 1.4rem;
-    line-height: 1.20849;
-    border-top: 1px solid hsl(0, 0%, 83.9%);
-    border-color: var(--toc-border-color);
-}
-
-article .table-of-contents label {
-    font-size: 1.7rem;
-    font-weight: 500;
-    margin-bottom: 1.65rem;
-}
-
-.table-of-contents ul {
-    margin: 0;
-    list-style: none;
-    margin-top: 1.65rem;
-}
-
-.table-of-contents .list > ul {
-    padding-left: 0;
-}
-
-.table-of-contents ul li {
-    margin-bottom: 1.65rem;
-}
-
-.table-of-contents ul li:last-child {
-    margin-bottom: 0;
-}
-
-.table-of-contents ul li > ul {
-    margin-top: 1.65rem;
-}
-
-.with-toc pre:nth-child(-n+6),
-#post-4132 pre:nth-child(-n+10) {
-    width: 55%;
-    z-index: -1;
-}
-
-/** Logo **/
-.site-logo {
-    float: left;
-    font-size: 3rem;
-    line-height: 1.04167;
-    letter-spacing: 0.015rem;
-    font-weight: 500;
-    text-rendering: optimizeLegibility;
-    display: inline-block;
-    background: url('images/webkit.svg') no-repeat;
-    padding: 1rem 0 1rem 5.5rem;
-    color: hsl(0, 0%, 100%);
-    color: var(--inverse-text-color);
-    -webkit-user-select: none;
-    user-select: none;
-}
-
-.hero .logo {
-    background-image: url('images/webkit.svg');
-}
-
-/** Status Page **/
-
-.feature-header:after,
-.property-header:after {
-    display: inline-block;
-    content: "";
-    background: url('images/menu-down.svg') no-repeat 50%;
-    background-size: 2rem;
-}
-
-
-
-/** Accessibility **/
-
-@media (prefers-reduced-motion) {
-    article,
-    .feature-status-page {
-        -webkit-animation: fade-in 0.7s;
-        animation: fade-in 0.7s;
-    }
-}
-
-/** Screen Breakpoints **/
-
-@media only screen and (max-width: 1180px) {
-    .page-width {
-        max-width: 1140px;
-        padding-left: 2rem;
-        padding-right: 2rem;
-    }
-
-    article .byline {
-        width: 60%;
-        margin: 0 auto;
-        float: none;
-        text-align: center;
-        margin-bottom: 3rem;
-        padding-right: 0;
-    }
-
-    article .byline p {
-        display: inline;
-    }
-}
-
-@media only screen and (max-width: 1000px) {
-    article.page h1 {
-        width: 90%;
-        margin-bottom: 3rem;
-    }
-
-    article .byline {
-        width: 60%;
-        margin: 0 auto;
-        float: none;
-        text-align: center;
-        margin-bottom: 3rem;
-    }
-
-    article .byline p {
-        display: inline;
-    }
-
-    article .bodycopy {
-        width: 90%;
-    }
-}
-
-@media only screen and (max-width: 1015px) {
-    .main-menu.label-toggle {
-        display: inline-block;
-        margin: 1.5rem 0 2.5rem;
-        height: 3rem;
-        width: 3rem;
-        background: url('images/menu-down.svg') no-repeat 50%;
-        cursor: pointer;
-
-        transition: transform 0.3s ease-out;
-
-        -webkit-filter: invert(100%);
-        filter: invert(100%);
-        perspective: 600;
-        transform: translateZ(10rem);
-    }
-
-    .menu-toggle:checked + .main-menu.label-toggle,
-    header .menu-item > .menu-toggle:checked + a > .label-toggle::after {
-        -webkit-transform: rotateX(-180deg);
-        -moz-transform: rotateX(-180deg);
-        transform: rotateX(-180deg);
-        perspective: 600;
-    }
-
-    header .menu {
-        display: none;
-        position: absolute;
-        left: 0;
-        margin-top: 1px;
-        padding-top: 3rem;
-        text-align: left;
-        width: 100vw;
-        overflow: hidden;
-        box-shadow: 0px 5px 5px hsla(0, 0%, 0%, 0.1);
-        box-shadow: var(--header-menu-shadow);
-
-        backdrop-filter: blur(20px);
-        -webkit-backdrop-filter: blur(10px);
-        background-color: hsla(0, 0%, 100%, 0.8);
-        background-color: var(--header-menu-background-color);
-    }
-
-    header nav a {
-        color: hsl(0, 0, 100%);
-        color: var(--text-color);
-    }
-    
-    header nav > .menu {
-        position: relative;
-    }
-
-    header .menu-toggle:checked ~ ul {
-        display: block;
-        opacity: 1;
-    }
-
-    header .menu-item-has-children .label-toggle::after {
-        -webkit-filter: invert(0%);
-        filter: invert(0%);
-    }
-
-    header .menu-main-menu-container >  ul > li {
-        width: 100vw;
-        position: relative;
-        padding: 0 3rem 3rem;
-        box-sizing: border-box;
-        transition: opacity 0.6s;
-    }
-
-    header .menu > .menu-item > .sub-menu {
-        box-shadow: none;
-        border-bottom: 1px solid hsl(0, 0%, 90.6%);
-        border-color: var(--submenu-border-color);
-    }
-
-    header .menu > .menu-item-has-children {
-        margin-left: 0;
-    }
-
-    header .sub-menu-layer {
-        text-align: left;
-        width: 100vw;
-        left: 50%;
-        margin-left: -50vw;
-        border-radius: 0;
-        border-left: none;
-        border-right: none;
-        opacity: 0;
-        transform: translateY(0);
-        transition: opacity 0.6s;
-    }
-
-    header .sub-menu-layer:after, .sub-menu-layer:before {
-        bottom: 100%;
-        left: 71%;
-        border: solid transparent;
-        content: " ";
-        height: 0;
-        width: 0;
-        position: absolute;
-        pointer-events: none;
-    }
-
-    header .sub-menu-layer:after {
-        border: none;
-        margin-left: -10px;
-    }
-
-    header .sub-menu-layer:before {
-        border: none;
-        margin-left: -11px;
-    }
-
-    header .menu > .menu-item:hover > .sub-menu,
-    header .menu > .menu-item > .menu-toggle:checked ~ .sub-menu {
-        position: relative;
-        top: 1.5rem;
-        margin-top: 0;
-    }
-
-    footer nav li {
-        padding: 0 3rem 3rem 0;
-    }
-
-    header .search-input,
-    .search-input {
-        width: 100%;
-        
-        background-image: var(--search-glyph);
-    
-        padding: 3px 3px 3px 30px;
-    
-        border: 1px solid hsl(0, 0%, 90.6%);
-        border-color: var(--submenu-border-color);
-        transition: none;
-        
-        color: var(--text-color);
-    }
-    
-    header .search-input:focus,
-    header .search-input:not([value=""]) {
-        width: 100%;
-        background-color: rgba(255,255,255,0.1);
-    }
-}
-
-@media only screen and (max-width: 690px) {
-    article h1 {
-        font-size: 3.4rem;
-    }
-
-    .featured-tile {
-        padding: 0;
-    }
-
-    .tile.spacer {
-        height: 0;
-        min-height: 0;
-        margin-bottom: 0;
-    }
-
-    .page-width {
-        max-width: 100vw;
-        padding-left: 1rem;
-        padding-right: 1rem;
-        overflow: hidden;
-        box-sizing: border-box;
-    }
-
-    .tile {
-        min-height: 375px;
-    }
-
-    .third-tile,
-    .two-thirds-tile {
-        width: calc(100% - 1px);
-    }
-
-    .icon-tile .icon {
-        margin-top: -40%;
-    }
-
-    .with-toc pre:nth-child(-n+8),
-    article pre {
-        position: relative;
-        width: 100vw;
-        left: 50%;
-        transform: translate(-50%);
-        margin-left: 0;
-        border-radius: 0;
-        border-left: none;
-        border-right: none;
-    }
-
-    .table-of-contents { /* hug the edge */
-        right: 0;
-    }
-
-    .pagination .prev-post,
-    .pagination .next-post {
-        min-width: auto;
-        width: 90%;
-        text-align: right;
-    }
-
-    .pagination .prev-post {
-        margin-bottom: 1rem;
-        text-align: left;
-    }
-
-    .nextrouter-copy {
-        font-size: 2.2rem;
-    }
-
-    article .scrollable {
-        overflow: auto;
-        -webkit-overflow-scrolling: touch;
-        position: relative;
-        width: 100vw;
-        left: 50%;
-        transform: translate(-50%);
-        margin: 3rem 0;
-        border: 1px solid hsl(0, 0%, 80%);
-        border-color: var(--article-scrollable-border-color);
-        border-left: none;
-        border-right: none;
-    }
-
-    article video.alignleft,
-    article video.alignright {
-        min-width: 30rem;
-    }
-
-    .scrollable .scrollable-padding {
-        display: inline-block;
-        padding: 0 3rem;
-    }
-    
-    .search-results h1 {
-        font-size: 5.4rem;
-    }
-
-    .search-results h1,
-    .search-results main form,
-    .search-results main .results-list {
-        width: 100%;
-        margin: 0 auto;
-    }
-}
-
-@media only screen and (max-width: 600px) {
-    header {
-        padding-top: 1rem;
-    }
-
-    .site-logo {
-        font-size: 4rem;
-        padding-left: 6.4rem;
-    }
-
-    header nav .main-menu.label-toggle {
-        margin-top: 2rem;
-        margin-bottom: 2rem;
-    }
-
-    #wpadminbar {
-        position: absolute;
-    }
-
-    .table-of-contents {
-        /* Collapse */
-        height: 7rem;
-        overflow: hidden;
-        border-bottom-width: 1px;
-        border-bottom-style: solid;
-
-        /* one-column */
-        width: 100vw;
-        max-width: 100%;
-        position: relative;
-        float: none;
-        padding-bottom: 2.5rem;
-        margin: 0 0 3rem 0;
-    }
-
-    .menu-toggle:checked ~ .table-of-contents {
-        height: auto;
-    }
-
-    .table-of-contents label {
-        display: block;
-    }
-
-    .table-of-contents label:after {
-        display: inline-block;
-        content: "";
-        background: url('images/menu-down.svg') no-repeat 50%;
-        background-size: 1rem;
-        width: 2rem;
-        height: 2rem;
-        position: absolute;
-        transition: transform 0.3s ease-out;
-        perspective: 600;
-    }
-
-    .menu-toggle:checked ~ .table-of-contents label:after {
-        -webkit-transform: rotateX(-180deg);
-        -moz-transform: rotateX(-180deg);
-        transform: rotateX(-180deg);
-    }
-
-    .table-of-contents h6 {
-        margin-bottom: 3rem;
-    }
-
-    .with-toc pre:nth-child(-n+6),
-    #post-4132 pre:nth-child(-n+8) {
-        width: 100vw;
-    }
-
-    article video.alignleft,
-    article video.alignright {
-        max-width: 100%;
-        min-width: none;
-        width: 100%;
-    }
-
-    article .alignleft:first-child,
-    article .alignright:first-child {
-        margin-bottom: 3rem;
-    }
-
-}
-
-@media only screen and (max-width: 415px) {
-    .nextrouter-copy {
-        font-size: 1.7rem;
-        letter-spacing: -0.016rem;
-    }
-}
-
-@media only screen and (max-height: 415px) and (max-width: 920px) {
-
-    .home .site-logo {
-        opacity: 1;
-        margin-top: 0;
-    }
-
-    header,
-    .home header {
-        padding-top: 1rem;
-    }
-
-    @supports(padding:max(0px)) {
-        header,
-        header .menu,
-        .home header,
-        .home .hero .content,
-        .feature-filters,
-        #content,
-        #nightly,
-        footer {
-            box-sizing: border-box;
-            padding-left: env(safe-area-inset-left);
-            padding-right: env(safe-area-inset-right);
-        }
-
-        header .menu .menu-item > .sub-menu {
-            border: none;
-            background: none;
-        }
-
-        .sub-menu-layer {
-            padding: 0 3rem;
-        }
-
-        .sub-menu-layer .menu-item:first-child,
-        .sub-menu-layer .menu-item {
-            padding: 0 0 1.5rem 1.5rem;
-        }
-
-    }
-
-    .tile {
-        overflow: hidden;
-    }
-
-    .tile .background-image {
-        padding-bottom: 33%;
-    }
-
-    .tile .background-image svg {
-        top: -65%;
-    }
-
-
-    .table-of-contents {
-        height: 9rem;
-        overflow: hidden;
-        margin-right: -10%;
-    }
-
-    .menu-toggle:checked ~ .table-of-contents {
-        height: auto;
-    }
-
-    .table-of-contents label {
-        display: block;
-    }
-
-    .table-of-contents label:after {
-        display: inline-block;
-        content: "";
-        background: url('images/menu-down.svg') no-repeat 50%;
-        background-size: 1rem;
-        width: 2rem;
-        height: 2rem;
-        position: absolute;
-        transition: transform 0.3s ease-out;
-        perspective: 600;
-    }
-
-    .menu-toggle:checked ~ .table-of-contents label:after {
-        -webkit-transform: rotateX(-180deg);
-        -moz-transform: rotateX(-180deg);
-        transform: rotateX(-180deg);
-    }
-
-    .table-of-contents h6 {
-        margin-bottom: 3rem;
-    }
-
-    .with-toc pre:nth-child(-n+6),
-    #post-4132 pre:nth-child(-n+8) {
-        width: 100vw;
-    }
-}
-
-@media(prefers-color-scheme:dark) {
-    article .invert-brightness,
-    figure > img {
-        filter: url(#invertLightness);
-    }
-
-    .preserve-color, video {
-        filter: brightness(0.7);
-        transition: filter 0.3s ease-out;
-    }
-
-    .preserve-color:hover,
-    figure:hover .preserve-color,
-    figure:hover video,
-    video:hover {
-        filter: brightness(1);
-    }
-
-    .nextrouter .link,
-    a.readmore {
-        background-image: url('images/chevron-dark.svg');
-    }
-
-    .table-of-contents label:after {
-        filter: invert(100%);
-    }
-
-    .md-typeset table:not([class]) {
-        background-color: revert;
-     }
-}
-
-/** webkit overrides **/
-article blockquote {
-    width: revert;
-    height: auto;
-    padding: 0 0;
-    left: revert;
-    position: revert;
-    margin-left: revert;
-    box-sizing: border-box;
-    font-weight: 200;
-    font-size: 1.3rem;
-    line-height: 1.6rem;
-    text-align: left;
-    color: hsl(240, 2.3%, 56.7%);
-    color: var(--text-color-coolgray);
-}
-
-/** md overrides */
-.md-header {
-    background-color: var(--background-color);
-}
-
-.md-nav {
-    font-size: .9rem;
-}
-
-.md-typeset :is(h1, h2, h3, h4, h5, h6),
-.md-typeset :is(h1, h2, h3, h4, h5, h6) a {
-    text-align: left;
-    font-weight: revert;
-    color: var(--text-color);
-    font-size: revert;
-}
-
-.md-typeset h1,
-.md-typeset h1 a {
-    font-size: 3rem;
-    margin-bottom: 0;
-}
-
-.md-typeset :is(h1, h2, h3, h4, h5, h6, code, p) {
-    font-weight: revert;
-    margin-bottom: 1rem;
-}
-
-.md-typeset pre {
-    padding: 0;
-    width: 100%;
-    margin: 0;
-}
-
-.md-typeset code {
-    color: var(--code-text-color);
-    background-color: var(--code-background-color);
-}
-
-.md-nav--primary .md-nav__title,
-.md-nav--secondary .md-nav__title[for=__toc] {
-    color: var(--text-color-heading);
-}
-
-.md-typeset .headerlink {
-    color: var(--text-color-coolgray);
-}
-
-.md-typeset .headerlink:focus, .md-typeset .headerlink:hover, .md-typeset :target>.headerlink {
-    color: var(--link-color);
-    text-decoration: none;
-}
-
-.md-nav__item .md-nav__link--active,
-.md-nav__link:focus, .md-nav__link:hover,
-:is(.md-nav, .md-typeset) a,
-:is(.md-nav, .md-typeset) a:hover {
+/* Sidebar */
+.md-nav__link {
     color: var(--link-color);
 }
 
-:is(.md-nav--primary, .md-nav--secondary) .md-nav__title {
-    background-color: revert;
-    box-shadow: none;
+.md-nav__link--passed {
+    opacity: 0.5;
 }
 
-.md-typeset table:not([class]) {
-    font-size: revert;
+.md-nav__link--active {
+    opacity: initial;
+    font-weight: bold;
 }
 
-.md-copyright {
-    color: var(--inverse-text-color);
-    font-size: 1rem;
-    margin: auto .6rem;
-    padding: .4rem 0;
-    width: 100%;
+.md-nav a:hover {
+    text-decoration: underline;
 }
 
-.md-grid {
-    max-width: 80rem;
+.md-tabs__link {
+    opacity: 1;
+    transform: 0.3s ease-out;
 }
 
-/** Search Box **/
-
-.md-search__input  {
-    font-size: revert;
-    font-size: 22px;
+.md-tabs__link:hover {
+    color: var(--link-color);
 }
 
-.md-search-result__meta {
-    padding-top: 0.5rem;
-    font-size: 14px;
-}
-
-.md-search__options {
-    display:flex;
-}
-
-::placeholder {
-    font-size: 1em;
-    padding: 5px;
-    visibility: hidden;
-  }
-
-.md-search__form {
-    display: flex;
-    border-radius: 1rem;
-}
-
-.md-search__input {
-  background-color: var(--content-background-color);
-}
-@media screen and (min-width:60em) {
-  .md-search__input+.md-search__icon {
-    color: var(--text-color);
-  }
-}
-
-.md-search__input,
-.md-search-result__meta,
-.md-search__options>.md-icon,
-[data-md-toggle=search]:checked~.md-header .md-search__input+.md-search__icon,
-[data-md-toggle=search]:checked~.md-header .md-search__form {
-  color: var(--text-color);
-}
-
-.md-search__scrollwrap {
-  background-color: var(--content-background-color);
-  color: var(--text-color);
-}
-
-.md-search-result__icon {
-  color: var(--text-color);
-}
-.md-search-result .md-typeset,
-.md-search-result .md-typeset :is(h1, h2, h3, h4, h5, h6, p) {
-  color: var(--text-color);
-  font-size: 1rem;
-}
-
-.md-search-result mark {
-  color: var(--link-color);
-}
-
-.md-search-result__more>summary>div,
-.md-search-result__more>summary:focus>div, 
-.md-search-result__more>summary:hover>div {
-  color: var(--link-color);
-  font-size: 0.9rem;
-}
-
-a.md-search-result__link,
-.md-search-result__link:focus,
-.md-search-result__link:hover {
-  text-decoration: none;
+/* Handle pop up menu on smaller screen sizes */
+.md-nav--primary .md-nav__title {
+    color: var(--md-primary-bg-color);
+    background-color: var(--md-primary-fg-color);
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,7 @@ theme:
   features:
     - header.autohide
     - search.share
+    - navigation.tabs
     - navigation.tracking
     - content.action.edit
 
@@ -16,12 +17,21 @@ theme:
 
 plugins:
   - search
+  - offline
 
 repo_url: https://github.com/webkit/Documentation
 edit_uri: blob/main/docs/
 
 extra:
   social:
+    - icon: fontawesome/brands/mastodon 
+      link: https://front-end.social/@webkit
+
+    - icon: fontawesome/brands/slack
+      link: https://webkit.slack.com
+
+    - icon: fontawesome/brands/github 
+      link: https://github.com/webkit/webkit
 
   generator: false
 
@@ -32,5 +42,5 @@ markdown_extensions:
       permalink: true
 
 extra_css:
-  - stylesheets/webkit.css    
+  - stylesheets/webkit.css
 


### PR DESCRIPTION
Improve styling to match webkit.org, and not rewrite the world

This commit builds on Martin Donath's work with not trying to override all the variables and using a lot of the built-ins.

I am only doing minor restyling of the text to closely match webkit.org's style. The rest of the styles should remain untouched. Colors are handled by over-riding the MkDocs Material colors with Webkit's color scheme.
