### PR TITLE
Rename GTK+ to GTK

### DIFF
--- a/docs/Build & Debug/BuildOptions.md
+++ b/docs/Build & Debug/BuildOptions.md
@@ -46,7 +46,7 @@ Tools/Scripts/build-webkit --debug --<platform>-device
 
 where `platform` is `ios`, `tvos` or `watchos`.
 
-## Building the GTK+ Port
+## Building the GTK Port
 
 For production builds:
 
@@ -64,7 +64,7 @@ Tools/Scripts/update-webkitgtk-libs
 Tools/Scripts/build-webkit --gtk --debug
 ```
 
-For more information on building WebKitGTK+, see the [wiki page](https://trac.webkit.org/wiki/BuildingGtk).
+For more information on building WebKitGTK, see the [wiki page](https://trac.webkit.org/wiki/BuildingGtk).
 
 ## Building the WPE Port
 


### PR DESCRIPTION
GTK+ and WebKitGTK+ dropped `+` four years ago [1][2].

[1] https://en.wikipedia.org/wiki/GTK

[2] Bug 194658 – [GTK] WebKitGTK+ -> WebKitGTK
    https://bugs.webkit.org/show_bug.cgi?id=194658
