### PR TITLE
Rename ImportWPTTests to WPTTests

### DIFF
--- a/docs/Infrastructure/WPTTests.md
+++ b/docs/Infrastructure/WPTTests.md
@@ -1,4 +1,4 @@
-# Import Web Platform Tests
+# Web Platform Tests Integration
 
 WebKit maintains a separate fork of the Web Platform Tests living in `‌LayoutTests/imported/w3c/web-platform-tests`. When changes are made upstream we need to import them to stay up to date.
 


### PR DESCRIPTION
We should ideally have a single page that contains information about our integration with WPT. Currently the page holds information for importing WPT tests, but we should also add steps to exporting tests. Renaming the title of the page to "Web Platform Tests Integration," makes it clear that this is the location for that type of information.