### PR TITLE
Removed "Ports/Windows port" subdirectory which contained a single file

### DIFF
--- a/docs/Build & Debug/BuildOptions.md
+++ b/docs/Build & Debug/BuildOptions.md
@@ -84,7 +84,7 @@ Tools/Scripts/build-webkit --wpe --debug
 
 ## Building Windows Port
 
-For building WebKit on Windows, see [Windows Port](../Ports/Windows port/Introduction.html).
+For building WebKit on Windows, see [Windows Port](../Ports/WindowsPort.md).
 
 ## Running WebKit
 

--- a/docs/Ports/WindowsPort.md
+++ b/docs/Ports/WindowsPort.md
@@ -109,7 +109,7 @@ The build succeeded if you got `WebKit is now built` message. Run your `MiniBrow
 WebKitBuild/Release/bin64/MiniBrowser.exe
 ```
 
-You can run programs under a debugger with [this instruction](../../Build & Debug/DebuggingWithVS.html).
+You can run programs under a debugger with [this instruction](../Build & Debug/DebuggingWithVS.md).
 
 ### Building from within Visual Studio
 


### PR DESCRIPTION
* Renamed "Ports/Windows port/Introduction.md" to "Ports/WindowsPort.md"
* Fixed broken links.
