### PR TITLE
[Win] Set PATH to WebKitLibraries\win\bin64

### DIFF
--- a/docs/Ports/Windows port/Introduction.md
+++ b/docs/Ports/Windows port/Introduction.md
@@ -60,7 +60,8 @@ path %ProgramFiles%\CMake\bin;%path%
 path %ProgramFiles(x86)%\Microsoft Visual Studio\Installer;%path%
 for /F "usebackq delims=" %%I in (`vswhere.exe -latest -property installationPath`) do set VSPATH=%%I
 
-set WEBKIT_LIBRARIES=%~dp0WebKitLibraries\win
+rem set WEBKIT_LIBRARIES=%~dp0WebKitLibraries\win
+path %~dp0WebKitLibraries\win\bin64;%path%
 set WEBKIT_TESTFONTS=%~dp0Tools\WebKitTestRunner\fonts
 set DUMPRENDERTREE_TEMP=%TEMP%
 


### PR DESCRIPTION
After the following change, Windows port needs a PATH to the output
directory to directly run executables and no longer need to set
WEBKIT_LIBRARIES environmental variable unless one wants to customize.

 https://commits.webkit.org/265819@main
 https://github.com/WebKit/WebKit/commit/21785f58f0ef78badabb6ab466a888bc5399cbf2
