### PR TITLE
Delete Build.md in Deep Dive

### DIFF
--- a/docs/Deep Dive/Build/Build.md
+++ b/docs/Deep Dive/Build/Build.md
@@ -1,9 +1,0 @@
-# Build
-
-The WebKit Build System
-
-## Overview
-
-WebKit can be built on a wide range of platforms and architectures. When performing a build on Apple platforms we use xcodebuild, and for non Apple platforms CMake is used instead.
-
-To find specific instructions on different build options please reference #Fixme.


### PR DESCRIPTION
This file contained very little information, and was mainly useful when we were using DocC.
