### PR TITLE
Add prominent https://webkit.org/ link to top page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@ hide:
 
 # WebKit Overview
 
-WebKit is a cross-platform web browser engine. On iOS and macOS, it powers Safari, Mail, iBooks, and many other applications.
+WebKit is a cross-platform web browser engine. On iOS and macOS, it powers Safari, Mail, iBooks, and many other applications. For more information about WebKit, see the [WebKit project website](https://webkit.org/).
 
 ## Getting Up and Running
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,9 @@ extra:
     - icon: fontawesome/brands/github 
       link: https://github.com/webkit/webkit
 
+    - icon: fontawesome/brands/safari
+      link: https://webkit.org
+
   generator: false
 
 copyright: WebKit and the WebKit logo are trademarks of Apple Inc.


### PR DESCRIPTION
<pre>
Add prominent https://webkit.org/ link to top page

A developer/reader coming in to the https://docs.webkit.org/ site would
likely find it pretty useful to also browse directly to the top of the
https://webkit.org/ site and explore all the other information about WebKit
which that site provides.

But the existing https://docs.webkit.org/ site doesn’t include any link
directly to the top of the https://webkit.org/ site.

Among the specific things linked to on the https://webkit.org/ site,
developers are likely to find the Feature Status tab in the top menu
to be useful — since it includes links to the Standards Positions and
CSS Features pages, which docs.webkit.org doesn’t link to (and
probably doesn’t need to).

See also https://commits.webkit.org/267977@main

* docs/index.md: Added link to https://webkit.org/
</pre>