### PR TITLE
Remove mentions of debug-test-runner, debug-minibrowser, and debug-safari scripts

### DIFF
--- a/docs/Build & Debug/DebuggingOnTheCommandLine.md
+++ b/docs/Build & Debug/DebuggingOnTheCommandLine.md
@@ -27,16 +27,6 @@ sys.path.insert(0, "{Path to WebKit}/Tools/gdb/")
 import webkit
 ```
 
-## Debug Launch Scripts
-
-WebKit comes with several helper scripts to make launching a debug session quicker.
-
-| Script | Description |
-| ------ | ----------- |
-| debug-minibrowser | Debug the Minibrowser application |
-| debug-safari      | Debug the Safari browser          |
-| debug-test-runner | Debug WebKitTestRunner            |
-
 ## Manually Debugging WebKit
 
 The helper scripts above provide an easy way to start debugging, but a user can choose to manually launch WebKit


### PR DESCRIPTION
These scripts don’t actually work, and nobody seems to be using them,
and they’ve not been touched in more than 6 years. https://github.com/WebKit/Documentation/issues/81

```
* docs/Build & Debug/DebuggingOnTheCommandLine.md:
```