### PR TITLE
Fix Visual Studio Debugging doc

### DIFF
--- a/docs/Build & Debug/DebuggingWithVS.md
+++ b/docs/Build & Debug/DebuggingWithVS.md
@@ -60,7 +60,7 @@ Note that you usually won't be able to pass a variable name as the parameter to 
 
 You can attach a single debugger to more than one process. To do this, launch or attach to the first process, then use Tools > Attach to Process… or Ctrl+Alt+P to attach to the second process. Your breakpoints will apply to both processes.
 
-There is a Visual Studio Extension to attach child processes automatically. ​Introducing the Child Process Debugging Power Tool
+There is a Visual Studio Extension to attach child processes automatically. [​Introducing the Child Process Debugging Power Tool](https://devblogs.microsoft.com/devops/introducing-the-child-process-debugging-power-tool/)
 
 There are two ways to see which process the debugger is currently operating on, and to switch the current process: the Processes window and the Debug Location toolbar. 
 You can open the Processes window using `Debug > Windows > Processes` or `Ctrl+Shift+Alt+P`. You can show the Debug Location toolbar using View > Toolbars > Debug Location.

--- a/docs/Build & Debug/DebuggingWithVS.md
+++ b/docs/Build & Debug/DebuggingWithVS.md
@@ -26,13 +26,8 @@ devenv -debugexe .\WebKitBuild\Debug\bin64\MiniBrowser.exe
 
 Follow the ​instructions for using [the Microsoft symbol server](https://learn.microsoft.com/en-us/windows-hardware/drivers/debugger/microsoft-public-symbols) so that Visual Studio can show you backtraces that involve closed-source components.
 
-## Using Watch Window
+Adding $err,hr to [the Watch Window](https://learn.microsoft.com/en-us/visualstudio/debugger/watch-and-quickwatch-windows?view=vs-2022) will show you what ::GetLastError() would return at this moment, and will show you both the numerical error value and the error string associated with it.
 
-You can open any of the Watch windows using the `Debug > Windows > Watch` submenu.
-
-​MSDN Magazine published a very useful ​article about Watch window pseudo-variables and format specifiers. Those of particular interest to WebKit developers are mentioned explicitly below, but the whole article is worth a read.
-
-Adding $err,hr to the Watch Window will show you what ::GetLastError() would return at this moment, and will show you both the numerical error value and the error string associated with it.
 Calling CFShow
 
 When debugging code that uses CF types, you can invoke the ​CFShow function in the Immediate window (Debug > Windows > Immediate or Ctrl+Alt+I) to print a debug description of a CF object to the Output window like so:

--- a/docs/Build & Debug/DebuggingWithVS.md
+++ b/docs/Build & Debug/DebuggingWithVS.md
@@ -8,8 +8,7 @@ Copy [​WebKit.natvis](https://github.com/WebKit/WebKit/blob/main/Tools/VisualS
 
 There are three ways to debugging WebKit with Visual Studio. Opening the generated WebKit.sln, opening an exe file directly, and attaching running WebKit.
 
-Invoke build-webkit, and open `WebKitBuild\Release\WebKit.sln` using Visual Studio.
-If you get errors about not being able to find .props files, run Tools/Scripts/update-webkit, then close and relaunch Cygwin and Visual Studio.
+[Invoke build-webkit with `--no-ninja --generate-project-only` options](../Ports/WindowsPort.html#building-from-within-visual-studio), and open by `devenv WebKitBuild\Release\WebKit.sln` or `devenv WebKitBuild\Debug\WebKit.sln` on [WebKit command prompt](../Ports/WindowsPort.html#webkit-command-prompt).
 
 Set MiniBrowser as the solution's StartUp project.
 Select the MiniBrowser project in the Solution Explorer, then choose `Project > Set as StartUp Project`. This will cause the project to turn bold in the Solution Explorer.

--- a/docs/Build & Debug/DebuggingWithVS.md
+++ b/docs/Build & Debug/DebuggingWithVS.md
@@ -6,7 +6,7 @@ Copy [​WebKit.natvis](https://github.com/WebKit/WebKit/blob/main/Tools/VisualS
 
 ## Debugging WebKit
 
-There are three ways to debugging WebKit with Visual Studio. Openning the generated WebKit.sln, openning an exe file directly, and attaching running WebKit.
+There are three ways to debugging WebKit with Visual Studio. Opening the generated WebKit.sln, opening an exe file directly, and attaching running WebKit.
 
 Invoke build-webkit, and open `WebKitBuild\Release\WebKit.sln` using Visual Studio.
 If you get errors about not being able to find .props files, run Tools/Scripts/update-webkit, then close and relaunch Cygwin and Visual Studio.

--- a/docs/Build & Debug/DebuggingWithVS.md
+++ b/docs/Build & Debug/DebuggingWithVS.md
@@ -22,19 +22,6 @@ In Ninja builds, there is no solution files. In such case, open the exe file dir
 devenv -debugexe .\WebKitBuild\Debug\bin64\MiniBrowser.exe
 ```
 
-## Debugging DumpRenderTree
-
-Set DumpRenderTree as your startup project.
-Configure the arguments and environment variables for the test runner.
-In the DumpRenderTree project in the Solution Explorer window, right-click and select Properties....
-
-In the Command Arguments section, enter the absolute paths for the tests you want to run, separated by spaces.
-In the Environment section, put `PATH=$(ProgramFiles)\Common Files\Apple\Apple Application Support;$(PATH)`
-Click OK to close the Project Properties window.
-
-Launch the debugger.
-Right-click on the DumpRenderTree project, and choose `Debug > Start New Instance`.
-
 ## Miscellaneous Tips
 
 Follow the ​instructions for using the Microsoft and Safari symbol servers so that Visual Studio can show you backtraces that involve closed-source components.

--- a/docs/Build & Debug/DebuggingWithVS.md
+++ b/docs/Build & Debug/DebuggingWithVS.md
@@ -24,7 +24,7 @@ devenv -debugexe .\WebKitBuild\Debug\bin64\MiniBrowser.exe
 
 ## Miscellaneous Tips
 
-Follow the ​instructions for using the Microsoft and Safari symbol servers so that Visual Studio can show you backtraces that involve closed-source components.
+Follow the ​instructions for using [the Microsoft symbol server](https://learn.microsoft.com/en-us/windows-hardware/drivers/debugger/microsoft-public-symbols) so that Visual Studio can show you backtraces that involve closed-source components.
 
 ## Using Watch Window
 

--- a/docs/Build & Debug/DebuggingWithVS.md
+++ b/docs/Build & Debug/DebuggingWithVS.md
@@ -28,15 +28,6 @@ Follow the ​instructions for using [the Microsoft symbol server](https://learn
 
 Adding $err,hr to [the Watch Window](https://learn.microsoft.com/en-us/visualstudio/debugger/watch-and-quickwatch-windows?view=vs-2022) will show you what ::GetLastError() would return at this moment, and will show you both the numerical error value and the error string associated with it.
 
-Calling CFShow
-
-When debugging code that uses CF types, you can invoke the ​CFShow function in the Immediate window (Debug > Windows > Immediate or Ctrl+Alt+I) to print a debug description of a CF object to the Output window like so:
-
-```
-{,,CoreFoundation}CFShow((void*)0x12345678)
-```
-Note that you usually won't be able to pass a variable name as the parameter to CFShow, as the Immediate window will get confused and think you're specifying a symbol in CoreFoundation.dll rather than whatever code you're debugging. It's usually easiest just to pass the address of the object directly as above.
-
 ## Debugging Multiple Processes
 
 You can attach a single debugger to more than one process. To do this, launch or attach to the first process, then use Tools > Attach to Process… or Ctrl+Alt+P to attach to the second process. Your breakpoints will apply to both processes.

--- a/docs/Build & Debug/DebuggingWithVS.md
+++ b/docs/Build & Debug/DebuggingWithVS.md
@@ -22,12 +22,6 @@ In Ninja builds, there is no solution files. In such case, open the exe file dir
 devenv -debugexe .\WebKitBuild\Debug\bin64\MiniBrowser.exe
 ```
 
-## Miscellaneous Tips
-
-Follow the ​instructions for using [the Microsoft symbol server](https://learn.microsoft.com/en-us/windows-hardware/drivers/debugger/microsoft-public-symbols) so that Visual Studio can show you backtraces that involve closed-source components.
-
-Adding $err,hr to [the Watch Window](https://learn.microsoft.com/en-us/visualstudio/debugger/watch-and-quickwatch-windows?view=vs-2022) will show you what ::GetLastError() would return at this moment, and will show you both the numerical error value and the error string associated with it.
-
 ## Debugging Multiple Processes
 
 You can attach a single debugger to more than one process. To do this, launch or attach to the first process, then use Tools > Attach to Process… or Ctrl+Alt+P to attach to the second process. Your breakpoints will apply to both processes.
@@ -47,3 +41,9 @@ You can inspect WebKit2 API types in Visual Studio by casting them to their unde
 {,,WebKit}(WebKit::MutableDictionary*)0x12345678
 ```
 The same technique will work for other WebKit2 API types as long as you substitute the appropriate type for MutableDictionary above.
+
+## Miscellaneous Tips
+
+Follow the ​instructions for using [the Microsoft symbol server](https://learn.microsoft.com/en-us/windows-hardware/drivers/debugger/microsoft-public-symbols) so that Visual Studio can show you backtraces that involve closed-source components.
+
+Adding $err,hr to [the Watch Window](https://learn.microsoft.com/en-us/visualstudio/debugger/watch-and-quickwatch-windows?view=vs-2022) will show you what ::GetLastError() would return at this moment, and will show you both the numerical error value and the error string associated with it.


### PR DESCRIPTION
# What this PR changes

- add links missed on migration from [trac](https://trac.webkit.org/wiki/Debugging%20With%20Visual%20Studio?version=17)
- remove obsolete sections
- fix typo