### PR TITLE
Update iBooks to Apple Books

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@ hide:
 
 # WebKit Overview
 
-WebKit is a cross-platform web browser engine. On iOS and macOS, it powers Safari, Mail, iBooks, and many other applications.
+WebKit is a cross-platform web browser engine. On iOS and macOS, it powers Safari, Mail, Apple Books, and many other applications.
 
 ## Getting Up and Running
 


### PR DESCRIPTION
iBooks was renamed to Apple Books several years ago.

* docs.index.md
