### PR TITLE
Logging: Add a section about setting up on Android

### DIFF
--- a/docs/Build & Debug/Logging.md
+++ b/docs/Build & Debug/Logging.md
@@ -81,6 +81,34 @@ Set the `WEBKIT_DEBUG` environment variable.
 WEBKIT_DEBUG=Scrolling Tools/Scripts/run-minibrowser --gtk --debug
 ```
 
+### Android
+
+The WPE port can be built for Android, where it integrates with the system
+`logd` service. The log channel configuration is read from the
+`debug.log.WPEWebKit` system property, which can be set using the `setprop`
+command line tool:
+
+```sh
+adb shell setprop debug.log.WPEWebKit 'WebGL,Media=error'
+```
+
+Additionally, the `log.tag.WPEWebKit` property is used to configure a global
+filter for all the messages produced by WebKit:
+
+```sh
+adb shell setprop log.tag.WPEWebKit VERBOSE
+```
+
+The `persist.` prefix may be added to either system property to store the
+setting across device reboots.
+
+Android logs can then read with `logcat`:
+
+```sh
+adb logcat -s WPEWebKit
+```
+
+
 ### macOS
 
 On macOS, you can, for example, enable the `Language` log channel with these terminal commands:


### PR DESCRIPTION
<pre>
Logging: Add a section about setting up on Android

Document that the WPE port logs to the logd service on Android,
and is configured using system properties, after the two following
patches:

- https://github.com/WebKit/WebKit/pull/47339
- https://github.com/WebKit/WebKit/pull/47352

* docs/Build & Debug/Logging.md: Add notes for WPE on Android.
</pre>

