### PR TITLE
Update WindowsPort.md as per #129 and other advisories

### DIFF
--- a/docs/Ports/WindowsPort.md
+++ b/docs/Ports/WindowsPort.md
@@ -123,7 +123,7 @@ In the WebKit command prompt, invoke `build-webkit` to start building:
 perl Tools/Scripts/build-webkit --release
 ```
 
-Recent WebKit versions will use [VCPKG](https://vcpkg.io) to build the required libraries.
+[Recent WebKit versions](https://commits.webkit.org/295042@main) will use [VCPKG](https://vcpkg.io) to build the required libraries.
 
 Older versions will automatically download required libraries from [WebKitRequirements](https://github.com/WebKitForWindows/WebKitRequirements) when you perform a `build-webkit`.
 It checks the latest WebKitRequirements every time, so it is recommended to use `--skip-library-update` for incremental builds to speed up the next time.


### PR DESCRIPTION
- Make users aware that cloning into a parent git repository can cause failure.
- Make users aware that having *"C++ Clang Tools for Windows"* installed may cause build failure and offer a workaround in the  Webkit Command Prompt script.
- As per #129, choco installs Cmake 4+ by default since ~March 2025. This causes downstream issues with vcpkg woff2. Use Cmake 3.23 instead.
- Add option to set ccmake for pch in the Webkit Command Prompt

