### PR TITLE
Logging: Fix spelling of Android property used to setup channels

### DIFF
--- a/docs/Build & Debug/Logging.md
+++ b/docs/Build & Debug/Logging.md
@@ -85,11 +85,11 @@ WEBKIT_DEBUG=Scrolling Tools/Scripts/run-minibrowser --gtk --debug
 
 The WPE port can be built for Android, where it integrates with the system
 `logd` service. The log channel configuration is read from the
-`debug.log.WPEWebKit` system property, which can be set using the `setprop`
+`debug.WPEWebKit.log` system property, which can be set using the `setprop`
 command line tool:
 
 ```sh
-adb shell setprop debug.log.WPEWebKit 'WebGL,Media=error'
+adb shell setprop debug.WPEWebKit.log 'WebGL,Media=error'
 ```
 
 Additionally, the `log.tag.WPEWebKit` property is used to configure a global


### PR DESCRIPTION
<pre>
Logging: Fix spelling of Android property used to setup channels

The correct name is debug.WPEWebKit.log, and not debug.log.WPEWebKit.

* docs/Build & Debug/Logging.md: Fix property name.
</pre>

