### PR TITLE
Remove update-webkitwpe-libs from gtk build example

### DIFF
--- a/docs/Build & Debug/BuildOptions.md
+++ b/docs/Build & Debug/BuildOptions.md
@@ -62,7 +62,6 @@ For development builds:
 
 ```
 Tools/gtk/install-dependencies
-Tools/Scripts/update-webkitgtk-libs
 Tools/Scripts/build-webkit --gtk --debug
 ```
 
@@ -80,7 +79,6 @@ For development builds:
 
 ```
 Tools/wpe/install-dependencies
-Tools/Scripts/update-webkitwpe-libs
 Tools/Scripts/build-webkit --wpe --debug
 ```
 


### PR DESCRIPTION
Since moving away from Flatpak this script isn't generally useful and by default it still downloads the flatpak runtime. Then build-webkit will try to use flatpak since the runtime exists.