### PR TITLE
docs: Add media-related module descriptions

### DIFF
--- a/docs/Deep Dive/Modules/Modules.md
+++ b/docs/Deep Dive/Modules/Modules.md
@@ -13,7 +13,7 @@ The source code for the Modules can be found [here](https://github.com/WebKit/We
 
 | Module | Description |
 | ------ | ----------- |
-| airplay             | |
+| airplay | Allows wireless playback of audio and video content to AirPlay-enabled devices such as Apple TV or compatible speakers. |
 | applepay            | |
 | applepay-ams-ui     | |
 | applicationmanifest | |
@@ -24,7 +24,7 @@ The source code for the Modules can be found [here](https://github.com/WebKit/We
 | contact-picker      | |
 | cookie-consent      | |
 | credentialmanagement| |
-| encryptedmedia      | |
+| encryptedmedia | Encrypted Media Extensions (EME) provides an API that enables web applications to interact with content protection systems to allow playback of encrypted media. |
 | entriesapi          | |
 | fetch               | |
 | filesystemaccess      | |
@@ -32,31 +32,31 @@ The source code for the Modules can be found [here](https://github.com/WebKit/We
 | geolocation           | |
 | highlight             | |
 | indexeddb             | A NoSQL database that allows long term storage of large amounts of data. |
-| mediacapabilities     | |
-| mediacontrols         | |
-| mediarecorder         | |
-| mediasession          | |
-| mediasource           | |
-| mediastream           | |
+| mediacapabilities | Allows applications to determine the playback and recording capabilities of the device, such as whether a codec is supported, smooth, or power-efficient. |
+| mediacontrols | Manages the standard user interface elements (play, pause, volume) provided by the browser for controlling media playback. |
+| mediarecorder | Provides recording of MediaStream into encoded media chunks for saving or uploading. |
+| mediasession | Enables web pages to provide custom metadata and action handlers to the operating system's media UI, allowing control via lock screen, notifications, or hardware keys. |
+| mediasource | Media Source Extensions allows clients to implement custom loading, buffering, and variant switching for media playback using the MediaSource and SourceBuffer APIs. |
+| mediastream | MediaStream provides real-time media capture and streaming primitives used by camera/microphone input and WebRTC pipelines. |
 | model-element         | |
-| modern-media-controls | |
+| modern-media-controls | Provides a modern JavaScript-based implementation of media controls for a consistent and rich media control experience across platforms. |
 | notifications     | |     
 | paymentrequest    | |     
 | pdfjs-extras      | PDFJS provides rendering PDF documents using JavaScript replacing the native PDF renderer. |     
 | permissions       | |     
-| pictureinpicture | |
+| pictureinpicture | Allows websites to create a floating video window so that users can continue consuming media while interacting with other content or applications. |
 | plugins | |
 | push-api | |
-| remoteplayback | |
+| remoteplayback | Provides mechanisms to control the playback of media on remote devices, such as smart TVs or wireless displays. |
 | reporting | |
 | speech | |
 | storage | |
-| streams | |
+| streams | Provides a set of primitives for creating, composing, and consuming streams of arbitrary data (binary or text). |
 | system-preview | |
 | web-locks | |
-| webaudio | |
+| webaudio | Provides a high-level JavaScript API for processing and synthesizing audio in web applications. |
 | webauthn | |
-| webcodecs | |
+| webcodecs | Provides low-level access to individual video frames and audio chunks for efficient encoding and decoding of media. |
 | webdatabase | |
 | webdriver | |
 | websockets | |


### PR DESCRIPTION
Add descriptions for media-related modules that were previously undocumented in the Modules table.
The descriptions follow the same style and format as the existing entries.
